### PR TITLE
Baud rate: Used the datasheet formula instead of hardcoded value

### DIFF
--- a/firmware/main.c
+++ b/firmware/main.c
@@ -292,7 +292,7 @@ static void hardwareInit(void)
 #endif
 
   /* set baud rate */
-  UBRRL	= 31;			/* 312500Hz at 16MHz clock */
+  UBRRL	= ((F_CPU / (16UL * 31250)) - 1); /* 31250Hz at the frequency defined in the Makefile */
   /*  */
   UCSRB	= (1<<RXEN) | (1<<TXEN);
   UCSRB |= (1<<RXCIE); //RECV INTERRUPT ENABLE


### PR DESCRIPTION
I wanted to use a 12MHz quartz instead of the 16MHz indicated in the Readme file, and I realized that I needed to change the value in two places: https://github.com/kehribar/Attiny2313-USB-MIDI/blob/1e20c93d7b0262d7b84344223de02447d56ed9b9/firmware/mico/Makefile#L10 and https://github.com/kehribar/Attiny2313-USB-MIDI/blob/1e20c93d7b0262d7b84344223de02447d56ed9b9/firmware/main.c#L295

The compiler will automatically define the F_CPU variable, so we can set the clock frequency in the Makefile and have it reflected in the code.

(also there was a typo in the comment: it should be 31250Hz and not 312500Hz)